### PR TITLE
Add documentation note about eslint no-unsafe

### DIFF
--- a/README.md
+++ b/README.md
@@ -2599,6 +2599,20 @@ type output = z.output<typeof stringToNumber>; // number
 type inferred = z.infer<typeof stringToNumber>; // number
 ```
 
+### Use with `@typescript-eslint/no-unsafe-*`
+
+Note that the type returned by `z.object(...)` is a `z.ZodObject` with its `Catchall` generic parameter set by default to `z.ZodTypeAny`, which is an alias for `z.ZodType<any, any, any>`. This naturally triggers ESLint rules like `@typescript-eslint/no-unsafe-argument`, which attempt to keep any use of `any` out of your codebase.
+
+A simple workaround to ensure compliance with this rules is to set `.catchall(z.never())`. For example:
+
+```ts
+const foo = z
+  .object({
+    bar: z.string(),
+  })
+  .catchall(z.never());
+```
+
 ### Writing generic functions
 
 When attempting to write a function that accepts a Zod schema as an input, it's common to try something like this:


### PR DESCRIPTION
Documenting this because it took me much too long to understand how `eslint` was getting triggered.